### PR TITLE
fixed small async race

### DIFF
--- a/src/applyWsHandler.ts
+++ b/src/applyWsHandler.ts
@@ -369,6 +369,7 @@ export function applyWSHandler<TRouter extends AnyRouter>(
       );
     },
     async open(client: WebSocket<Decoration>) {
+      allClients.add(client);
       async function createContextAsync() {
         const data = client.getUserData();
 
@@ -411,7 +412,6 @@ export function applyWSHandler<TRouter extends AnyRouter>(
         }
       }
       await createContextAsync();
-      allClients.add(client);
     },
 
     async message(client: WebSocket<Decoration>, rawMsg) {


### PR DESCRIPTION
The `open` event was adding to `allClients` after an async `createContextAsync` call, which caused a small race condition where the `close` event could run before, causing an error when sending messages to a closed client