### PR TITLE
revert to getPostBody to support async getContext

### DIFF
--- a/src/fetchRequest.spec.ts
+++ b/src/fetchRequest.spec.ts
@@ -16,7 +16,7 @@ function createServer(opts: { maxBodySize: number | null }) {
   app.any('/*', async (res, req) => {
     const resDecorated = decorateHttpResponse(res);
 
-    const request = uWsToRequest(req, resDecorated, opts);
+    const request = await uWsToRequest(req, resDecorated, opts);
     await handle!(request).then(resolveHandler).catch(rejectHandler);
     res.cork(() => {
       res.end();

--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -62,9 +62,12 @@ export function applyRequestHandler<TRouter extends AnyRouter>(
   const handler = async (res: HttpResponse, req: HttpRequest) => {
     const url = req.getUrl().substring(prefix.length + 1);
     const resDecorated = decorateHttpResponse(res, opts.ssl);
-    const reqFetch = uWsToRequest(req, resDecorated, {
+    const reqFetch = await uWsToRequest(req, resDecorated, {
       maxBodySize: opts.maxBodySize ?? null,
     });
+    if (resDecorated.aborted) {
+      return;
+    }
 
     await uWsRequestHandler({
       ...opts.trpcOptions,

--- a/src/server.spec.ts
+++ b/src/server.spec.ts
@@ -40,8 +40,11 @@ const config = {
   prefix: '/trpc',
 };
 
-function createContext({ req, res, info, client }: CreateContextOptions) {
+async function createContext({ req, res, info, client }: CreateContextOptions) {
   const user = { name: req.headers.get('username') || 'anonymous' };
+
+  // add arbitrary delay to simulate async response
+  // await new Promise((resolve) => setTimeout(resolve, 10));
 
   if (req.headers.has('throw')) {
     throw new TRPCError({
@@ -71,7 +74,9 @@ function createContext({ req, res, info, client }: CreateContextOptions) {
   // filter out so that this is not triggered during subscription
   // but really, responseMeta should be used instead!
   if (info.type === 'query') {
-    res.writeHeader('x-test', 'true');
+    res.cork(() => {
+      res.writeHeader('x-test', 'true');
+    });
   }
   return { req, res, user, info, client };
 }


### PR DESCRIPTION
This PR reverts the `createBody` in favor of (a slightly updated version to pass tests) `getPostBody` from `v10`.

I was seeing #27 and after spending a few hours on it today, found the issue was the body reader. Something internal in `@trpc/server` is trying to read the stream twice, but I wasn't able to track down where the issue was coming from.

 I'm not very versed in `ReadableStream` so I'm not sure what benefits it has over using `getPostBody`, would love to learn if there are!