### PR TITLE
fix for small race condition in setting `res.aborted`

### DIFF
--- a/src/fetchCompat.ts
+++ b/src/fetchCompat.ts
@@ -154,6 +154,7 @@ function createBody(
 
       res.onAborted(() => {
         if (!hasClosed) {
+          res.aborted = true;
           hasClosed = true;
           controller.error(new TRPCError({ code: 'CLIENT_CLOSED_REQUEST' }));
         }

--- a/src/fetchCompat.ts
+++ b/src/fetchCompat.ts
@@ -160,6 +160,7 @@ function createBody(
       });
     },
     cancel() {
+      res.aborted = true;
       res.cork(() => {
         res.close();
       });


### PR DESCRIPTION
This one was tricky to find, but there's a small race condition leading to the library trying to `res.cork` and already aborted request