### PR TITLE
fix: fix installation via bun

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,11 @@
   "peerDependencies": {
     "uWebSockets.js": "*"
   },
+  "peerDependenciesMeta": {
+    "uWebSockets.js": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.24.0",


### PR DESCRIPTION
Since the peer-dependency doesn't exist in the registry, it needs to be marked so that bun doesn't error out during installation.